### PR TITLE
Break out k8s

### DIFF
--- a/cluster.tf
+++ b/cluster.tf
@@ -16,15 +16,13 @@ module "gke_application_cluster_regions" {
   authenticator_security_group = "gke-security-groups@dapperlabs.com"
 
 
-  addons                     = try(var.common_config.gke_addons, {})
-  node_locations             = var.gke_node_locations
-  master_authorized_ranges   = var.common_config.gke_master_authorized_ranges
-  private_cluster_config     = merge(var.common_config.gke_private_cluster_config, { master_ipv4_cidr_block = var.gke_networking.master_ipv4_cidr_block })
-  labels                     = try(var.common_config.gke_labels, {})
-  namespaces                 = var.common_config.gke_namespaces
-  workload_identity_profiles = var.common_config.gke_workload_identity_profiles
-  vertical_pod_autoscaling   = try(var.common_config.gke_vertical_pod_autoscaling, false)
-  secondary_region           = true
+  addons                   = try(var.common_config.gke_addons, {})
+  node_locations           = var.gke_node_locations
+  master_authorized_ranges = var.common_config.gke_master_authorized_ranges
+  private_cluster_config   = merge(var.common_config.gke_private_cluster_config, { master_ipv4_cidr_block = var.gke_networking.master_ipv4_cidr_block })
+  labels                   = try(var.common_config.gke_labels, {})
+  vertical_pod_autoscaling = try(var.common_config.gke_vertical_pod_autoscaling, false)
+  secondary_region         = true
 }
 
 module "gke_application_cluster_nodepools_regions" {

--- a/cluster.tf
+++ b/cluster.tf
@@ -1,8 +1,5 @@
 module "gke_application_cluster_regions" {
-  source = "github.com/dapperlabs-platform/terraform-google-gke-cluster?ref=v0.10.2"
-  providers = {
-    kubernetes = kubernetes.regions
-  }
+  source = "github.com/dapperlabs-platform/terraform-google-gke-cluster?ref=v0.10.3"
 
   project_id                   = var.common_config.project_id
   name                         = "${var.region}-application"

--- a/variables.tf
+++ b/variables.tf
@@ -9,12 +9,6 @@ variable "common_config" {
     environment = string # env: like staging or prod
     project_id  = string # the GCP project to deploy resources into
 
-    # The workload identity profiles to use for each cluster
-    gke_workload_identity_profiles = map(list(object({
-      email                           = string,
-      automount_service_account_token = optional(bool)
-    })))
-
     # Which IP ranges are allowed to communicate with the control plane
     gke_master_authorized_ranges = map(string)
 
@@ -44,9 +38,6 @@ variable "common_config" {
       enable_private_endpoint = bool
       master_global_access    = bool
     })
-
-    # Which namespaces to create in the cluster
-    gke_namespaces = list(string)
   })
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -13,21 +13,5 @@ terraform {
       source  = "hashicorp/google-beta"
       version = ">= 6.0"
     }
-    kubernetes = {
-      source                = "hashicorp/kubernetes"
-      version               = ">= 2.20"
-      configuration_aliases = [kubernetes.regions]
-    }
   }
-}
-
-data "google_client_config" "provider" {}
-
-provider "kubernetes" {
-  alias = "regions"
-  host  = "https://${module.gke_application_cluster_regions.endpoint}"
-  token = data.google_client_config.provider.access_token
-  cluster_ca_certificate = base64decode(
-    module.gke_application_cluster_regions.ca_certificate,
-  )
 }


### PR DESCRIPTION
In order to have a better dev experience when scaling up and down alternate regions, it makes the most sense to decouple the GKE and GCP resources from the Kubernetes based resources. These Kubernetes resources (including workload identity config) will be split out into it's own module and should probably eventually be moved to ArgoCD configuration. 